### PR TITLE
Add JSON-API endpoint for adding applications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# See http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[{*.yml,*.json}]
+indent_style = space
+indent_size = 2

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -1,17 +1,57 @@
-"use strict";
-const express = require("express");
-const logger = require("morgan");
+'use strict';
+const express = require('express');
+const logger = require('morgan');
+const applicationsService = require('../../services/applications');
 
 const app = express();
 
-app.use(logger("dev"));
+app.use(logger('dev'));
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
 
-app.get("/add-application", function(req, res) {
-  res.json({
-    status: "success"
-  });
+function normaliseError(error) {
+    let errorCode = {
+        status: 400,
+        code: 'APPLICATION-001',
+        title: 'Unknown error'
+    };
+
+    switch (error.message) {
+        case 'Validation error':
+            errorCode = {
+                status: 400,
+                code: 'APPLICATION-002',
+                title: 'Validation error'
+            };
+            break;
+        default:
+            break;
+    }
+
+    return errorCode;
+}
+
+app.post('/application/add', async function(req, res) {
+    res.setHeader('Content-Type', 'application/vnd.api+json');
+
+    try {
+        const record = await applicationsService.storeApplication({
+            formId: req.body.formId,
+            shortCode: req.body.shortCode,
+            applicationData: req.body.applicationData
+        });
+
+        res.json({
+            data: {
+                type: 'application',
+                id: record.reference_id
+            }
+        });
+    } catch (error) {
+        const normalisedError = normaliseError(error);
+        res.status(normalisedError.status).json({
+            error: normalisedError
+        });
+    }
 });
 
 module.exports = app;

--- a/models/application.js
+++ b/models/application.js
@@ -1,30 +1,31 @@
-"use strict";
+'use strict';
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define(
-    "Application",
-    {
-      form_id: {
-        type: DataTypes.STRING,
-        allowNull: false
-      },
-      reference_id: {
-        type: DataTypes.STRING,
-        allowNull: false
-      },
-      application_data: {
-        type: DataTypes.JSON
-      }
-    },
-    {
-      getterMethods: {
-        formTitle() {
-          // via https://stackoverflow.com/questions/196972/convert-string-to-title-case-with-javascript#comment85199999_46959528
-          return this.form_id
-            .replace(/-/g, " ")
-            .replace(/\b\S/g, t => t.toUpperCase());
+    return sequelize.define(
+        'Application',
+        {
+            form_id: {
+                type: DataTypes.STRING,
+                allowNull: false
+            },
+            reference_id: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: true
+            },
+            application_data: {
+                type: DataTypes.JSON
+            }
+        },
+        {
+            getterMethods: {
+                formTitle() {
+                    // via https://stackoverflow.com/questions/196972/convert-string-to-title-case-with-javascript#comment85199999_46959528
+                    return this.form_id
+                        .replace(/-/g, ' ')
+                        .replace(/\b\S/g, t => t.toUpperCase());
+                }
+            }
         }
-      }
-    }
-  );
+    );
 };

--- a/models/index.js
+++ b/models/index.js
@@ -1,43 +1,44 @@
-"use strict";
-const fs = require("fs");
-const path = require("path");
-const Sequelize = require("sequelize");
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
 
 const sequelize = new Sequelize(process.env.MYSQL_CONNECTION_URI, {
-  logging: false,
-  dialect: "mysql",
-  define: {
-    charset: "utf8mb4",
-    dialectOptions: {
-      collate: "utf8mb4_general_ci"
+    logging: false,
+    dialect: 'mysql',
+    define: {
+        charset: 'utf8mb4',
+        dialectOptions: {
+            collate: 'utf8mb4_general_ci'
+        }
+    },
+    operatorsAliases: false,
+    pool: {
+        max: 5,
+        min: 1,
+        idle: 10000
     }
-  },
-  operatorsAliases: false,
-  pool: {
-    max: 5,
-    min: 1,
-    idle: 10000
-  }
 });
 
 const db = {};
 const basename = path.basename(__filename);
-fs
-  .readdirSync(__dirname)
-  .filter(file => {
-    return (
-      file.indexOf(".") !== 0 && file !== basename && file.slice(-3) === ".js"
-    );
-  })
-  .forEach(file => {
-    var model = sequelize["import"](path.join(__dirname, file));
-    db[model.name] = model;
-  });
+fs.readdirSync(__dirname)
+    .filter(file => {
+        return (
+            file.indexOf('.') !== 0 &&
+            file !== basename &&
+            file.slice(-3) === '.js'
+        );
+    })
+    .forEach(file => {
+        var model = sequelize['import'](path.join(__dirname, file));
+        db[model.name] = model;
+    });
 
 Object.keys(db).forEach(modelName => {
-  if (db[modelName].associate) {
-    db[modelName].associate(db);
-  }
+    if (db[modelName].associate) {
+        db[modelName].associate(db);
+    }
 });
 
 db.sequelize = sequelize;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node ./bin/www",
     "startDev": "DEBUG=applications-service:* nodemon ./bin/www",
     "test": "eslint .",
-    "format": "prettier --write {apps,bin,models,services}/**/* README.md"
+    "format": "prettier --single-quote --write {apps,models,services}/**/* README.md"
   },
   "eslintConfig": {
     "plugins": ["node"],

--- a/services/applications.js
+++ b/services/applications.js
@@ -1,57 +1,57 @@
-"use strict";
-const hash = require("object-hash");
-const { Op, fn } = require("sequelize");
+'use strict';
+const hash = require('object-hash');
+const { Op, fn } = require('sequelize');
 
-const { Application } = require("../models");
+const { Application } = require('../models');
 
-function getReferenceId(prefix, applicationData) {
-  return `${prefix}-${hash
-    .sha1(applicationData)
-    .slice(0, 6)
-    .toUpperCase()}`;
+function getReferenceId(shortCode, applicationData) {
+    return `${shortCode}-${hash
+        .sha1(applicationData)
+        .slice(0, 6)
+        .toUpperCase()}`;
 }
 
-function storeApplication(formId, prefix, applicationData) {
-  return Application.create({
-    form_id: formId,
-    reference_id: getReferenceId(prefix, applicationData),
-    application_data: applicationData
-  });
+function storeApplication({ formId, shortCode, applicationData }) {
+    return Application.create({
+        form_id: formId,
+        reference_id: getReferenceId(shortCode, applicationData),
+        application_data: applicationData
+    });
 }
 
 function getAvailableForms() {
-  return Application.findAll({
-    order: [["form_id", "ASC"]],
-    group: ["form_id"],
-    attributes: ["form_id", [fn("COUNT", "id"), "count"]]
-  });
+    return Application.findAll({
+        order: [['form_id', 'ASC']],
+        group: ['form_id'],
+        attributes: ['form_id', [fn('COUNT', 'id'), 'count']]
+    });
 }
 
 function getApplicationsByForm(formId) {
-  return Application.findAll({
-    order: [["updatedAt", "DESC"]],
-    where: {
-      form_id: {
-        [Op.eq]: formId
-      }
-    }
-  });
+    return Application.findAll({
+        order: [['updatedAt', 'DESC']],
+        where: {
+            form_id: {
+                [Op.eq]: formId
+            }
+        }
+    });
 }
 
 function getApplicationsById(applicationId) {
-  return Application.findOne({
-    where: {
-      reference_id: {
-        [Op.eq]: applicationId
-      }
-    }
-  });
+    return Application.findOne({
+        where: {
+            reference_id: {
+                [Op.eq]: applicationId
+            }
+        }
+    });
 }
 
 module.exports = {
-  getReferenceId,
-  storeApplication,
-  getApplicationsByForm,
-  getApplicationsById,
-  getAvailableForms
+    getReferenceId,
+    storeApplication,
+    getApplicationsByForm,
+    getApplicationsById,
+    getAvailableForms
 };


### PR DESCRIPTION
Adds endpoint for `POST`ing application data. Succcess response looks like this:

```json
{
	"data": {
		"type": "application",
		"id": "BCF-ABC123"
	}
}
```

Matches http://jsonapi.org/format/ where `id` is our generated reference ID, not the internal database ID.

For error responses we return an error code, again based on http://jsonapi.org/format

```json
{
	"error": {
		"status": 400,
		"code": "APPLICATION-002",
		"title": "Validation error"
	}
}
```