### PR TITLE
Update value formatting

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ function initViewEngine() {
         autoescape: true,
         express: app,
         noCache: isDev === true,
-        watch: isDev  === true
+        watch: isDev === true
     });
 
     /**
@@ -73,7 +73,7 @@ function initViewEngine() {
      * @param {String} format
      * @see https://momentjs.com/docs/#/displaying/format/
      */
-    templateEnv.addFilter('formatDate', function(dateString, format) {
+    templateEnv.addFilter('formatDate', function (dateString, format) {
         return moment(dateString).tz("Europe/London").format(format);
     });
 
@@ -81,14 +81,15 @@ function initViewEngine() {
      * View helper to represent date as relative time
      * @param {String} dateString
      */
-    templateEnv.addFilter('timeFromNow', function(dateString) {
+    templateEnv.addFilter('timeFromNow', function (dateString) {
         return moment(dateString).tz("Europe/London").fromNow();
     });
 
-    // via https://stackoverflow.com/a/35260295
-    templateEnv.addFilter('nl2br', function(str) {
-        return str.replace(/\r|\n|\r\n/g, '<br />');
-    });
+    /**
+     * View helper to check if a value is an array
+     * @param {Array} xs
+     */
+    templateEnv.addFilter('isArray', xs => Array.isArray(xs));
 
     app.set('view engine', 'njk').set('engineEnv', templateEnv);
 }

--- a/apps/dashboard/index.js
+++ b/apps/dashboard/index.js
@@ -15,7 +15,6 @@ function getCleanAbsoluteUrl(req) {
 }
 
 router.route('/search/:formId').post(auth.ensureAuthenticated, async (req, res, next) => {
-
     function redirectToError() {
         req.session.noResultsFound = true;
         req.session.save(() => {
@@ -34,7 +33,6 @@ router.route('/search/:formId').post(auth.ensureAuthenticated, async (req, res, 
     } else {
         return res.redirect(`/dashboard/${req.params.formId}/${application.reference_id}`);
     }
-
 });
 
 router.route('/:formId?/:applicationId?').get(auth.ensureAuthenticated, async (req, res, next) => {

--- a/apps/dashboard/views/dashboard.njk
+++ b/apps/dashboard/views/dashboard.njk
@@ -120,10 +120,8 @@
                         {% for field in fieldset.fields %}
                             {% if field.value %}
                                 <h5>{{ field.label }}</h5>
-                                {% if field.type === 'textarea' %}
-                                    <p>{{ field.value | striptags(true) | escape | nl2br }}</p>
-                                {% elseif field.type === 'checkbox' %}
-                                    <p>{{ field.value | joinIfArray(', ') }}</p>
+                                {% if (field.value | isArray) %}
+                                    <p>{{ field.value | join(', ') }}</p>
                                 {% else %}
                                     <p>{{ field.value | nl2br | safe }}</p>
                                 {% endif %}


### PR DESCRIPTION
`nl2br` already exists as a filter so we shouldn't need to define it again. That said I think the order and logic of the formatting was what was causing issues. We don't have a `type` property so we don't need that check and we're autoescaping values so the order of filters needed tweaking.

Also spotted that if you selected multiple options for a checkbox value this would happen:

<img width="1092" alt="screen shot 2018-07-17 at 09 18 38" src="https://user-images.githubusercontent.com/123386/42805353-81f6e72e-89a3-11e8-9358-4ca4afb87a44.png">

End result is:

- If the value is an array (i.e. a checkbox or other multiple selection value) then join with a delimiter
- Otherwise pass to nl2br