### PR TITLE
Use suggested min for step-size

### DIFF
--- a/apps/dashboard/views/dashboard.njk
+++ b/apps/dashboard/views/dashboard.njk
@@ -230,7 +230,7 @@
                                 },
                                 ticks: {
                                     beginAtZero: true,
-                                    stepSize: 10
+                                    suggestedMin: 10
                                 }
                             }]
                         }


### PR DESCRIPTION
Use suggested min for step-size. Improves handling of larger values by mostly relying on auto-fit